### PR TITLE
Add translation for string "working notes"

### DIFF
--- a/locale/en/LC_MESSAGES/main.po
+++ b/locale/en/LC_MESSAGES/main.po
@@ -21,6 +21,9 @@ msgstr "Hibernating"
 msgid "username"
 msgstr "Username"
 
+msgid "Working Notes"
+msgstr "Working Notes"
+
 msgid "email"
 msgstr "Email"
 


### PR DESCRIPTION
This commit adds a badly-needed translated string for the title of the website :cat: :cactus: 
